### PR TITLE
Improve code view for passage editor

### DIFF
--- a/Map Builder Tool/README.md
+++ b/Map Builder Tool/README.md
@@ -25,6 +25,7 @@ A local web-based map editor for creating structured map data for Twine 2 / Suga
 - **Passage Generation**: Auto-generate Twine passage stubs for all map content
 - **Memory Persistence**: Form data preserved when navigating between nodes
 - **Visual Feedback**: Enhanced connectors show transition types and conditions
+- **Professional Passage Editor**: WYSIWYG editor with Visual, Code, and Preview modes for writing SugarCube passages
 
 ## Getting Started
 
@@ -63,6 +64,10 @@ Click on the blue connectors between cells to create transitions:
   - **Item**: Player must have a specific item
   - **Quest**: Player must have completed a quest
   - **Variable**: Check a game variable's value
+
+### Editing Passage Text
+
+Each node can open the **Professional Passage Editor**. Use this tool to craft passages with a friendly Visual view, a Preview, and a raw **Code** view that now displays SugarCube macros without HTML escaping.
 
 ### Exporting Maps
 

--- a/Map Builder Tool/main.js
+++ b/Map Builder Tool/main.js
@@ -3800,24 +3800,24 @@ function convertCodeToVisual(code) {
     // Convert passage links
     visual = visual.replace(/\[\[(.*?)\]\]/g, '<a href="#" class="passage-link">$1</a>');
     
-    // Convert macros to visual representations
-    visual = visual.replace(/<<link\s+"([^"]+)">>(.*?)<<\/link>>/gs, 
-        '<span class="interactive-span" data-macro-type="link">$1</span>');
-    
-    visual = visual.replace(/<<replace\s+"#([^"]+)">>(.*?)<<\/replace>>/gs, 
-        '<span class="interactive-span" data-macro-type="replace" data-target="$1">Replace: $1</span>');
-    
-    visual = visual.replace(/<<append\s+"#([^"]+)">>(.*?)<<\/append>>/gs, 
-        '<span class="interactive-span" data-macro-type="append" data-target="$1">Append: $1</span>');
-    
-    visual = visual.replace(/<<if\s+(.*?)>>(.*?)<<\/if>>/gs, 
-        '<div class="interactive-span" data-macro-type="conditional">If: $1<br>$2</div>');
-    
-    visual = visual.replace(/<<set\s+(.*?)>>/g, 
-        '<span class="interactive-span" data-macro-type="variable">Set: $1</span>');
-    
-    visual = visual.replace(/<<audio\s+"([^"]+)"\s+(\w+).*?>>/g, 
-        '<span class="interactive-span" data-macro-type="audio">Audio: $1 ($2)</span>');
+    // Convert macros to visual representations, preserving the original macro
+    visual = visual.replace(/<<link\s+"([^"]+)">([\s\S]*?)<<\/link>>/g,
+        (m, text) => `<span class="interactive-span" data-macro="${encodeURIComponent(m)}" data-macro-type="link">${text}</span>`);
+
+    visual = visual.replace(/<<replace\s+"#([^"]+)">([\s\S]*?)<<\/replace>>/g,
+        (m, target) => `<span class="interactive-span" data-macro="${encodeURIComponent(m)}" data-macro-type="replace" data-target="${target}">Replace: ${target}</span>`);
+
+    visual = visual.replace(/<<append\s+"#([^"]+)">([\s\S]*?)<<\/append>>/g,
+        (m, target) => `<span class="interactive-span" data-macro="${encodeURIComponent(m)}" data-macro-type="append" data-target="${target}">Append: ${target}</span>`);
+
+    visual = visual.replace(/<<if\s+([^>]+)>>([\s\S]*?)<<\/if>>/g,
+        (m, cond) => `<div class="interactive-span" data-macro="${encodeURIComponent(m)}" data-macro-type="conditional">If: ${cond}<br></div>`);
+
+    visual = visual.replace(/<<set\s+([^>]+)>>/g,
+        (m, expr) => `<span class="interactive-span" data-macro="${encodeURIComponent(m)}" data-macro-type="variable">Set: ${expr}</span>`);
+
+    visual = visual.replace(/<<audio\s+"([^"]+)"\s+(\w+).*?>>/g,
+        (m, file, act) => `<span class="interactive-span" data-macro="${encodeURIComponent(m)}" data-macro-type="audio">Audio: ${file} (${act})</span>`);
     
     // Convert named spans
     visual = visual.replace(/<span\s+id="([^"]+)"([^>]*)>(.*?)<\/span>/gs, 
@@ -3832,7 +3832,11 @@ function convertCodeToVisual(code) {
 function convertVisualToCode(visual) {
     // Convert visual representation back to Twine/SugarCube code
     let code = visual;
-    
+
+    // Replace interactive macro placeholders with their original code
+    code = code.replace(/<(span|div)[^>]*data-macro="([^"]+)"[^>]*>.*?<\/(span|div)>/gs,
+        (m, _tag, macro) => decodeURIComponent(macro));
+
     // Remove visual-only classes and attributes
     code = code.replace(/\s*class="[^"]*interactive-span[^"]*"/g, '');
     code = code.replace(/\s*class="[^"]*named-span[^"]*"/g, '');
@@ -3846,13 +3850,18 @@ function convertVisualToCode(visual) {
     
     // Convert passage links
     code = code.replace(/<a[^>]*class="passage-link"[^>]*>(.*?)<\/a>/g, '[[$1]]');
-    
+
     // Convert line breaks
     code = code.replace(/<br\s*\/?>/g, '\n');
-    
-    // Clean up extra whitespace
-    code = code.replace(/\s+/g, ' ').trim();
-    
+
+    // Decode HTML entities so macros appear correctly
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = code;
+    code = textarea.value;
+
+    // Preserve user spacing
+    code = code.trim();
+
     return code;
 }
 


### PR DESCRIPTION
## Summary
- add Professional Passage Editor info to README
- show macros in the Professional Passage Editor's code view

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6851fa5c13188329a48995303915c751